### PR TITLE
Server handle_write callback added

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ export OPEN62541_BUILD_ARGS='-DCMAKE_BUILD_TYPE=Release -DUA_NAMESPACE_ZERO=MINI
 
 Default values for `OPEN62541_BUILD_ARGS` are `-DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo -DUA_NAMESPACE_ZERO=FULL`.
 
+## TODO
+
+  * **Encryption**
+  * **Client's Search Node function**
+  * **Methods**
+  * **Subscription**
+  * **Server configuration through env, map or something**
+  * **Better handling c code for the Client and Server common code**
+
   <!-- * **Note** Currently only the **Client implementation as synchronous** of Snap7 is available. Future implementations can be found in our [TODO](#todo) section.
 
   * Opex62541 is developed for open62541 "1.0.0" and Elixir 1.9.0. It is tested on:
@@ -276,10 +285,3 @@ git clone --recursive git@github.com:valiot/snap7.git
 ## License
 
   See [LICENSE](./LICENSE).
-  
-## TODO
-  * **Better handling c code**
-  * **Server implementation**
-  * **Partner implementation**
-  * **Asynchronous Client implementation**
- -->

--- a/test/server_tests/refactor_test.exs
+++ b/test/server_tests/refactor_test.exs
@@ -2,14 +2,14 @@ defmodule ServerRefactorTest do
   use ExUnit.Case
   doctest Opex62541
 
-  alias OpcUA.{NodeId, Server, QualifiedName}
+  alias OpcUA.Server
 
   setup do
-    {:ok, pid} = OpcUA.Server.start_link()
+    {:ok, pid} = Server.start_link()
     %{pid: pid}
   end
 
   test "test", state do
-    :ok = OpcUA.Server.test(state.pid)
+    :ok = Server.test(state.pid)
   end
 end

--- a/test/server_tests/write_event_test.exs
+++ b/test/server_tests/write_event_test.exs
@@ -1,0 +1,87 @@
+defmodule ServerWriteEventTest do
+  use ExUnit.Case
+  doctest Opex62541
+
+  alias OpcUA.{NodeId, Client}
+
+  defmodule MyServer do
+    use OpcUA.Server
+    alias OpcUA.{NodeId, Server, QualifiedName}
+
+    def start_link() do
+      GenServer.start(__MODULE__, self(), [])
+    end
+
+    # Use the `init` function to configure your server.
+    def init(parent_pid) do
+      {:ok, s_pid} = Server.start_link()
+      :ok = Server.set_default_config(s_pid)
+
+      {:ok, _ns_index} = Server.add_namespace(s_pid, "Room")
+
+      # Object Node
+      requested_new_node_id =
+        NodeId.new(ns_index: 1, identifier_type: "integer", identifier: 10002)
+
+      parent_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 85)
+      reference_type_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 35)
+      browse_name = QualifiedName.new(ns_index: 1, name: "Test1")
+      type_definition = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 58)
+
+      :ok = Server.add_object_node(s_pid,
+        requested_new_node_id: requested_new_node_id,
+        parent_node_id: parent_node_id,
+        reference_type_node_id: reference_type_node_id,
+        browse_name: browse_name,
+        type_definition: type_definition
+      )
+
+      # Variable Node
+      requested_new_node_id =
+        NodeId.new(ns_index: 1, identifier_type: "integer", identifier: 10001)
+
+      parent_node_id = NodeId.new(ns_index: 1, identifier_type: "integer", identifier: 10002)
+      reference_type_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 47)
+      browse_name = QualifiedName.new(ns_index: 1, name: "Var")
+      type_definition = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 63)
+
+      :ok = Server.add_variable_node(s_pid,
+        requested_new_node_id: requested_new_node_id,
+        parent_node_id: parent_node_id,
+        reference_type_node_id: reference_type_node_id,
+        browse_name: browse_name,
+        type_definition: type_definition
+      )
+
+      :ok = Server.write_node_write_mask(s_pid, requested_new_node_id, 0x3FFFFF)
+      :ok = Server.write_node_access_level(s_pid, requested_new_node_id, 3)
+
+      :ok = Server.start(s_pid)
+
+      {:ok, %{s_pid: s_pid, parent_pid: parent_pid}}
+    end
+
+    def handle_write(write_event, %{parent_pid: parent_pid} = state) do
+      send(parent_pid, write_event)
+      state
+    end
+  end
+
+  setup() do
+    {:ok, _pid} = MyServer.start_link()
+
+    {:ok, c_pid} = Client.start_link()
+    :ok = Client.set_config(c_pid)
+    :ok = Client.connect_by_url(c_pid, url: "opc.tcp://alde-Satellite-S845:4840/")
+
+    %{c_pid: c_pid}
+  end
+
+  test "Write value event", %{c_pid: c_pid} do
+    node_id =  NodeId.new(ns_index: 1, identifier_type: "integer", identifier: 10001)
+    assert :ok == Client.write_node_value(c_pid, node_id, 0, true)
+    c_response = Client.read_node_value(c_pid, node_id)
+    assert c_response == {:ok, true}
+    assert_receive({node_id, true}, 1000)
+  end
+end


### PR DESCRIPTION
# Description

A callback has been added to the Server  that handles node values updates from a Client or Server. It's first argument will a tuple, in which its first element is the `node_id` of the updated node and the second element is the updated value.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
test/server_tests/write_event_test.exs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
