### PR TITLE
Alde103/inrpd285 opc ua subscriptions

### DIFF
--- a/lib/opc_ua/client.ex
+++ b/lib/opc_ua/client.ex
@@ -533,6 +533,7 @@ defmodule OpcUA.Client do
   end
 
   # Subscription C message handlers
+
   defp handle_c_response(
          {:subscription, {:data, subscription_id, monitored_id, c_value}},
          %{controlling_process: c_pid} = state

--- a/lib/opc_ua/nodestore/monitored_item.ex
+++ b/lib/opc_ua/nodestore/monitored_item.ex
@@ -1,0 +1,37 @@
+defmodule OpcUA.MonitoredItem do
+  use IsEnumerable
+  use IsAccessible
+
+  alias OpcUA.NodeId
+
+  @moduledoc """
+  A Monitored Item is used to request a server for notifications of each change of value in a specific node.
+  """
+  @enforce_keys [:args]
+
+  defstruct args: nil
+
+  @doc """
+  Creates an structure for an Monitored Item of an existing node in a Server.
+  The following options must be filled:
+    * `:monitored_item` -> %NodeId().
+    * `:sampling_time` -> double().
+    * `:subscription_id` -> integer().
+  """
+  @spec new(list()) :: %__MODULE__{}
+  def new(args) when is_list(args) do
+    with  monitored_item <- Keyword.fetch!(args, :monitored_item),
+          sampling_time <- Keyword.fetch!(args, :sampling_time),
+          subscription_id <- Keyword.get(args, :subscription_id, 0),
+          %NodeId{} <- monitored_item,
+          true <- is_float(sampling_time),
+          true <- is_integer(subscription_id)
+    do
+      struct(%__MODULE__{args: args})
+    else
+      _ ->
+        raise("Invalid argument: sampling_time must be a float number and monitored_item must be %OpcUA.NodeId{} struct")
+    end
+  end
+  def new(_invalid_data), do: raise("Expecting ")
+end

--- a/lib/opc_ua/server.ex
+++ b/lib/opc_ua/server.ex
@@ -137,8 +137,10 @@ defmodule OpcUA.Server do
       end
 
       @impl true
-      def handle_write(write_event, _state) do
-        raise "No handle_write/2 clause in #{__MODULE__} provided for #{inspect(write_event)}"
+      def handle_write(write_event, state) do
+        require Logger
+        Logger.warn("No handle_write/2 clause in #{__MODULE__} provided for #{inspect(write_event)}")
+        state
       end
 
       @impl true

--- a/lib/opc_ua/server.ex
+++ b/lib/opc_ua/server.ex
@@ -533,6 +533,16 @@ defmodule OpcUA.Server do
         :exit_status
       ])
 
+    #Valgrind
+    # port =
+    #   Port.open({:spawn_executable, to_charlist("/usr/bin/valgrind.bin")}, [
+    #     {:args, ["-q", "--leak-check=full", "--show-leak-kinds=all", "--track-origins=yes", "--show-reachable=no", executable]},
+    #     {:packet, 2},
+    #     :use_stdio,
+    #     :binary,
+    #     :exit_status
+    #   ])
+
     state = %State{port: port, controlling_process: controlling_process}
     {:ok, state}
   end

--- a/src/common.c
+++ b/src/common.c
@@ -769,7 +769,7 @@ void decode_caller_metadata(const char *req, int *req_index, const char* cmd)
     if(ei_decode_tuple_header(req, req_index, &tuple_arity) < 0 || tuple_arity != 2)
             errx(EXIT_FAILURE, "caller metadata requires a 2-tuple, term_size = %d", tuple_arity);
 
-    caller_function = malloc(strlen(cmd));
+    caller_function = malloc(strlen(cmd) + 1);
     strcpy(caller_function, cmd);
     
     caller_pid = malloc(sizeof(erlang_pid));
@@ -2806,9 +2806,11 @@ void handle_read_node_executable(void *entity, bool entity_type, const char *req
  */
 void handle_read_node_value(void *entity, bool entity_type, const char *req, int *req_index)
 {
-    UA_Variant *value = UA_Variant_new(); ;
+    UA_Variant *value = UA_Variant_new();
     UA_StatusCode retval;
     UA_NodeId node_id = assemble_node_id(req, req_index);
+
+    UA_Variant_init(value);
    
     if(entity_type)
         retval = UA_Client_readValueAttribute((UA_Client *)entity, node_id, value);

--- a/src/common.c
+++ b/src/common.c
@@ -1,21 +1,3 @@
-/*
- *  Copyright 2016 Frank Hunleth
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-#define CLIENT
-
-
 #include "common.h"
 #include "open62541.h"
 #include "erlcmd.h"
@@ -886,7 +868,7 @@ void send_monitored_item_delete_response(void *subscription_id, void *monitored_
     ei_encode_tuple_header(resp, &resp_index, 2);
     ei_encode_atom(resp, &resp_index, "subscription");
 
-    ei_encode_tuple_header(resp, &resp_index, 4);
+    ei_encode_tuple_header(resp, &resp_index, 3);
     ei_encode_atom(resp, &resp_index, "delete");
     encode_data_response(resp, &resp_index, subscription_id, 27, 0);
     encode_data_response(resp, &resp_index, monitored_id, 27, 0);
@@ -1114,7 +1096,6 @@ void send_write_response(UA_Server *server,
         // TODO: UA_TYPES_VIEWATTRIBUTES
 
         case UA_TYPES_UADPNETWORKMESSAGECONTENTMASK:
-            errx(EXIT_FAILURE, "checar");
             send_write_data_response(nodeId, data->value.data, 2, 0);
         break;
 
@@ -1128,7 +1109,6 @@ void send_write_response(UA_Server *server,
         break;
 
         default:
-            errx(EXIT_FAILURE, "error");
             send_write_data_response(nodeId, data->value.data, 2, -1);
         break;
     }

--- a/src/common.h
+++ b/src/common.h
@@ -64,6 +64,10 @@ void encode_server_on_the_network_struct(char *resp, int *resp_index, void *data
 void encode_application_description_struct(char *resp, int *resp_index, void *data, int data_len);
 void encode_endpoint_description_struct(char *resp, int *resp_index, void *data, int data_len);
 void encode_server_config(char *resp, int *resp_index, void *data);
+void send_subscription_timeout_response(void *data, int data_type, int data_len);
+void send_subscription_deleted_response(void *data, int data_type, int data_len);
+void send_monitored_item_response(void *subscription_id, void *monitored_id, void *data, int data_type, int data_len);
+void send_monitored_item_delete_response(void *subscription_id, void *monitored_id);
 void send_data_response(void *data, int data_type, int data_len);
 void send_error_response(const char *reason);
 void send_ok_response();

--- a/src/opc_ua_client.c
+++ b/src/opc_ua_client.c
@@ -578,10 +578,17 @@ void handle_add_subscription(void *entity, bool entity_type, const char *req, in
     int term_type;
     UA_CreateSubscriptionResponse response;
 
+    double publishing_interval;
+    if (ei_decode_double(req, req_index, &publishing_interval) < 0) {
+        send_error_response("einval");
+        return;
+    }
+
     UA_ClientConfig *client_config = UA_Client_getConfig(client);
     client_config->subscriptionInactivityCallback = subscriptionInactivityCallback;
 
     UA_CreateSubscriptionRequest request = UA_CreateSubscriptionRequest_default();
+    request.requestedPublishingInterval = (UA_Double) publishing_interval;
     response = UA_Client_Subscriptions_create(client, request, NULL, NULL, deleteSubscriptionCallback);
 
     if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {

--- a/src/opc_ua_client.c
+++ b/src/opc_ua_client.c
@@ -9,10 +9,153 @@
 #include "erlcmd.h"
 #include "common.h"
 
-static const char response_id = 'r';
-
 UA_Client *client;
 
+/************************************/
+/* Default Client backend callbacks */
+/************************************/
+
+static void subscriptionInactivityCallback (UA_Client *client, UA_UInt32 subscription_id, void *subContext) 
+{
+    send_subscription_timeout_response(&subscription_id, 27, 0);
+}
+
+static void deleteSubscriptionCallback(UA_Client *client, UA_UInt32 subscription_id, void *subscriptionContext) 
+{
+    send_subscription_deleted_response(&subscription_id, 27, 0);
+}
+
+static void dataChangeNotificationCallback(UA_Client *client, UA_UInt32 subscription_id, void *subContext, UA_UInt32 monitored_id, void *monContext, UA_DataValue *data) 
+{
+     switch(data->value.type->typeIndex)
+    {
+        case UA_TYPES_BOOLEAN:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 0, 0);
+        break;
+
+        case UA_TYPES_SBYTE:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 23, 0);
+        break;
+
+        case UA_TYPES_BYTE:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 24, 0);
+        break;
+
+        case UA_TYPES_INT16:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 25, 0);
+        break;
+        
+        case UA_TYPES_UINT16:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 26, 0);
+        break;
+
+        case UA_TYPES_INT32:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 1, 0);
+        break;
+
+        case UA_TYPES_UINT32:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 2, 0);
+        break;
+
+        case UA_TYPES_INT64:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 15, 0);
+        break;
+
+        case UA_TYPES_UINT64:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 16, 0);
+        break;
+
+        case UA_TYPES_FLOAT:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 17, 0);
+        break;
+
+        case UA_TYPES_DOUBLE:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 4, 0);
+        break;
+
+        case UA_TYPES_STRING:
+            send_monitored_item_response(&subscription_id, &monitored_id, (*(UA_String *)data->value.data).data, 5, (*(UA_String *)data->value.data).length);
+        break;
+
+        case UA_TYPES_DATETIME:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 15, 0);
+        break;
+
+        case UA_TYPES_GUID:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 18, 0);
+        break;
+
+        case UA_TYPES_BYTESTRING:
+            send_monitored_item_response(&subscription_id, &monitored_id, (*(UA_ByteString *)data->value.data).data, 5, (*(UA_ByteString *)data->value.data).length);
+        break;
+
+        case UA_TYPES_XMLELEMENT:
+            send_monitored_item_response(&subscription_id, &monitored_id, (*(UA_XmlElement *)data->value.data).data, 5, (*(UA_XmlElement *)data->value.data).length);
+        break;
+
+        case UA_TYPES_NODEID:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 12, 0);
+        break;
+
+        case UA_TYPES_EXPANDEDNODEID:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 19, 0);
+        break;
+
+        case UA_TYPES_STATUSCODE:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 20, 0);
+        break;
+
+        case UA_TYPES_QUALIFIEDNAME:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 13, 0);
+        break;
+
+        case UA_TYPES_LOCALIZEDTEXT:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 14, 0);
+        break;
+
+        // TODO: UA_TYPES_EXTENSIONOBJECT
+    
+        // TODO: UA_TYPES_DATAVALUE
+
+        // TODO: UA_TYPES_VARIANT
+
+        // TODO: UA_TYPES_DIAGNOSTICINFO
+
+        case UA_TYPES_SEMANTICCHANGESTRUCTUREDATATYPE:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 21, 0);
+        break;
+
+        case UA_TYPES_TIMESTRING:
+            send_monitored_item_response(&subscription_id, &monitored_id, (*(UA_TimeString *)data->value.data).data, 5, (*(UA_TimeString *)data->value.data).length);
+        break;
+
+        // TODO: UA_TYPES_VIEWATTRIBUTES
+
+        case UA_TYPES_UADPNETWORKMESSAGECONTENTMASK:
+            errx(EXIT_FAILURE, "checar");
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 2, 0);
+        break;
+
+        case UA_TYPES_XVTYPE:
+            //errx(EXIT_FAILURE, "checar2");
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 22, 0);
+        break;
+
+        case UA_TYPES_ELEMENTOPERAND:
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 27, 0);
+        break;
+
+        default:
+            errx(EXIT_FAILURE, "error");
+            send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 2, -1);
+        break;
+    }
+}
+
+static void deleteMonitoredItemCallback(UA_Client *client, UA_UInt32 subscription_id, void *subContext, UA_UInt32 monitored_id, void *monContext)
+{
+    send_monitored_item_delete_response(&subscription_id, &monitored_id);
+}
 /***************************************/
 /* Configuration & Lifecycle Functions */
 /***************************************/
@@ -416,6 +559,134 @@ void handle_add_reference(void *entity, bool entity_type, const char *req, int *
     send_ok_response();
 }
 
+/***********************************************/
+/* Subscriptions and Monitored Items functions */
+/***********************************************/
+
+/*  Subscriptions
+ *
+ *  Subscriptions in OPC UA are asynchronous. That is, the client sends several PublishRequests to the server. 
+ *  The server returns PublishResponses with notifications. But only when a notification has been generated. 
+ *  The client does not wait for the responses and continues normal operations.
+ *  Note the difference between Subscriptions and MonitoredItems. Subscriptions are used to report back notifications. 
+ *  MonitoredItems are used to generate notifications. Every MonitoredItem is attached to exactly one Subscription. 
+ *  And a Subscription can contain many MonitoredItems.
+ */
+
+void handle_add_subscription(void *entity, bool entity_type, const char *req, int *req_index)
+{
+    int term_size;
+    int term_type;
+    UA_CreateSubscriptionResponse response;
+
+    UA_ClientConfig *client_config = UA_Client_getConfig(client);
+    client_config->subscriptionInactivityCallback = subscriptionInactivityCallback;
+
+    UA_CreateSubscriptionRequest request = UA_CreateSubscriptionRequest_default();
+    response = UA_Client_Subscriptions_create(client, request, NULL, NULL, deleteSubscriptionCallback);
+
+    if(response.responseHeader.serviceResult != UA_STATUSCODE_GOOD) {
+        send_opex_response(response.responseHeader.serviceResult);
+        return;
+    }
+
+    send_data_response(&(response.subscriptionId), 27, 0);
+}
+
+void handle_delete_subscription(void *entity, bool entity_type, const char *req, int *req_index)
+{
+    unsigned long subscription_id;
+    if (ei_decode_ulong(req, req_index, &subscription_id) < 0) {
+        send_error_response("einval");
+        return;
+    }
+
+    UA_StatusCode retval = UA_Client_Subscriptions_deleteSingle(client, (UA_UInt32) subscription_id);
+
+    if(retval != UA_STATUSCODE_GOOD) {
+        send_opex_response(retval);
+        return;
+    }
+
+    send_ok_response();
+}
+
+/*  Monitored Items
+ *
+ *  Subscriptions in OPC UA are asynchronous. That is, the client sends several PublishRequests to the server. 
+ *  The server returns PublishResponses with notifications. But only when a notification has been generated. 
+ *  The client does not wait for the responses and continues normal operations.
+ *  Note the difference between Subscriptions and MonitoredItems. Subscriptions are used to report back notifications. 
+ *  MonitoredItems are used to generate notifications. Every MonitoredItem is attached to exactly one Subscription. 
+ *  And a Subscription can contain many MonitoredItems.
+ */
+
+void handle_add_monitored_item(void *entity, bool entity_type, const char *req, int *req_index)
+{
+    int term_size;
+    int term_type;
+    UA_MonitoredItemCreateResult monitored_item_response;
+
+    if(ei_decode_tuple_header(req, req_index, &term_size) < 0 ||
+        term_size != 2)
+        errx(EXIT_FAILURE, ":handle_add_monitored_item requires a 2-tuple, term_size = %d", term_size);
+
+    UA_NodeId monitored_node = assemble_node_id(req, req_index);
+
+    unsigned long subscription_id;
+    if (ei_decode_ulong(req, req_index, &subscription_id) < 0) {
+        send_error_response("einval");
+        return;
+    }
+    
+    UA_MonitoredItemCreateRequest monitored_item_request = UA_MonitoredItemCreateRequest_default(monitored_node);
+
+    monitored_item_response = UA_Client_MonitoredItems_createDataChange(client, subscription_id,
+                                                                        UA_TIMESTAMPSTORETURN_BOTH, monitored_item_request,
+                                                                        NULL, dataChangeNotificationCallback, deleteMonitoredItemCallback);
+
+    UA_NodeId_clear(&monitored_node);
+
+    if(monitored_item_response.statusCode != UA_STATUSCODE_GOOD) {
+        send_opex_response(monitored_item_response.statusCode);
+        return;
+    }
+
+    send_data_response(&(monitored_item_response.monitoredItemId), 27, 0);
+}
+
+void handle_delete_monitored_item(void *entity, bool entity_type, const char *req, int *req_index)
+{
+    int term_size;
+    int term_type;
+    UA_StatusCode retval;
+
+    if(ei_decode_tuple_header(req, req_index, &term_size) < 0 ||
+        term_size != 2)
+        errx(EXIT_FAILURE, ":handle_delete_monitored_item requires a 2-tuple, term_size = %d", term_size);
+
+    unsigned long subscription_id;
+    if (ei_decode_ulong(req, req_index, &subscription_id) < 0) {
+        send_error_response("einval");
+        return;
+    }
+
+    unsigned long monitored_item_id;
+    if (ei_decode_ulong(req, req_index, &monitored_item_id) < 0) {
+        send_error_response("einval");
+        return;
+    }
+
+    retval = UA_Client_MonitoredItems_deleteSingle(client, (UA_UInt32) subscription_id, (UA_UInt32) monitored_item_id);
+
+    if(retval != UA_STATUSCODE_GOOD) {
+        send_opex_response(retval);
+        return;
+    }
+
+    send_ok_response();
+}
+
 /*******************************/
 /* Elixir -> C Message Handler */
 /*******************************/
@@ -474,6 +745,11 @@ static struct request_handler request_handlers[] = {
     {"find_servers_on_network", handle_find_servers_on_network},
     {"find_servers", handle_find_servers}, 
     {"get_endpoints", handle_get_endpoints},
+    // Subscriptions and Monitored Items functions.
+    {"add_subscription", handle_add_subscription},
+    {"delete_subscription", handle_delete_subscription},
+    {"add_monitored_item", handle_add_monitored_item},
+    {"delete_monitored_item", handle_delete_monitored_item},
     // Node Addition and Deletion
     {"add_variable_node", handle_add_variable_node},
     {"add_variable_type_node", handle_add_variable_type_node},

--- a/src/opc_ua_client.c
+++ b/src/opc_ua_client.c
@@ -27,7 +27,7 @@ static void deleteSubscriptionCallback(UA_Client *client, UA_UInt32 subscription
 
 static void dataChangeNotificationCallback(UA_Client *client, UA_UInt32 subscription_id, void *subContext, UA_UInt32 monitored_id, void *monContext, UA_DataValue *data) 
 {
-     switch(data->value.type->typeIndex)
+    switch(data->value.type->typeIndex)
     {
         case UA_TYPES_BOOLEAN:
             send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 0, 0);
@@ -132,12 +132,11 @@ static void dataChangeNotificationCallback(UA_Client *client, UA_UInt32 subscrip
         // TODO: UA_TYPES_VIEWATTRIBUTES
 
         case UA_TYPES_UADPNETWORKMESSAGECONTENTMASK:
-            errx(EXIT_FAILURE, "checar");
             send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 2, 0);
         break;
 
         case UA_TYPES_XVTYPE:
-            //errx(EXIT_FAILURE, "checar2");
+
             send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 22, 0);
         break;
 
@@ -146,7 +145,6 @@ static void dataChangeNotificationCallback(UA_Client *client, UA_UInt32 subscrip
         break;
 
         default:
-            errx(EXIT_FAILURE, "error");
             send_monitored_item_response(&subscription_id, &monitored_id, data->value.data, 2, -1);
         break;
     }

--- a/src/opc_ua_server.c
+++ b/src/opc_ua_server.c
@@ -460,6 +460,8 @@ void handle_add_monitored_item(void *entity, bool entity_type, const char *req, 
     
     retval = UA_Server_createDataChangeMonitoredItem(server, UA_TIMESTAMPSTORETURN_SOURCE,
                                             monitor_request, NULL, dataChangeNotificationCallback);
+    
+    UA_NodeId_clear(&monitored_node);
 
     if(retval.statusCode != UA_STATUSCODE_GOOD) {
         send_opex_response(retval.statusCode);

--- a/src/opc_ua_server.c
+++ b/src/opc_ua_server.c
@@ -468,6 +468,27 @@ void handle_add_monitored_item(void *entity, bool entity_type, const char *req, 
         return;
     }
 
+    send_data_response(&(retval.monitoredItemId), 27, 0);
+}
+
+void handle_delete_monitored_item(void *entity, bool entity_type, const char *req, int *req_index)
+{
+    int term_size;
+    int term_type;
+
+    unsigned long monitored_item_id;
+    if (ei_decode_ulong(req, req_index, &monitored_item_id) < 0) {
+        send_error_response("einval");
+        return;
+    }
+    
+    UA_StatusCode retval = UA_Server_deleteMonitoredItem(server, (UA_UInt32) monitored_item_id);
+
+    if(retval != UA_STATUSCODE_GOOD) {
+        send_opex_response(retval);
+        return;
+    }
+
     send_ok_response();
 }
 
@@ -517,6 +538,7 @@ static struct request_handler request_handlers[] = {
     {"read_node_executable", handle_read_node_executable},
     // Local MonitoredItems
     {"add_monitored_item", handle_add_monitored_item},
+    {"delete_monitored_item", handle_delete_monitored_item},
     // Node Addition and Deletion
     {"add_namespace", handle_add_namespace},
     {"add_variable_node", handle_add_variable_node},

--- a/test/client_tests/connection_test.exs
+++ b/test/client_tests/connection_test.exs
@@ -1,6 +1,5 @@
 defmodule ClientConnectionTest do
   use ExUnit.Case
-  doctest Opex62541
 
   alias OpcUA.{Client, Server}
 

--- a/test/client_tests/discovery_test.exs
+++ b/test/client_tests/discovery_test.exs
@@ -33,7 +33,7 @@ defmodule CClientDiscoveryTest do
 
     url = "opc.tcp://localhost:4840"
 
-    c_response = Client.get_endpoints(c_pid, url: url)
+    c_response = Client.get_endpoints(c_pid, url)
     assert c_response == desired
   end
 
@@ -53,7 +53,7 @@ defmodule CClientDiscoveryTest do
 
     url = "opc.tcp://localhost:4840"
 
-    c_response = Client.find_servers(c_pid, url: url)
+    c_response = Client.find_servers(c_pid, url)
     assert c_response == desired
   end
 
@@ -77,7 +77,7 @@ defmodule CClientDiscoveryTest do
 
     url = "opc.tcp://localhost:4840"
 
-    c_response = Client.find_servers_on_network(c_pid, url: url)
+    c_response = Client.find_servers_on_network(c_pid, url)
     #TODO: Add Server discovery
     assert c_response == {:error, "BadNotImplemented"}
   end

--- a/test/client_tests/discovery_test.exs
+++ b/test/client_tests/discovery_test.exs
@@ -1,8 +1,6 @@
 defmodule CClientDiscoveryTest do
   use ExUnit.Case
 
-  doctest Opex62541
-
   alias OpcUA.{Client, Server}
 
   setup do

--- a/test/client_tests/lifecycle_test.exs
+++ b/test/client_tests/lifecycle_test.exs
@@ -1,6 +1,5 @@
 defmodule CClientLifecycleTest do
   use ExUnit.Case
-  doctest Opex62541
 
   #alias OpcUA.{NodeId, Server, QualifiedName}
   alias OpcUA.Client

--- a/test/client_tests/monitored_items_test.exs
+++ b/test/client_tests/monitored_items_test.exs
@@ -1,0 +1,85 @@
+defmodule ClientMonitoredItemsTest do
+  use ExUnit.Case
+
+  alias OpcUA.{NodeId, Server, QualifiedName, Client}
+
+  setup do
+    {:ok, pid} = OpcUA.Server.start_link()
+    Server.set_default_config(pid)
+    {:ok, ns_index} = OpcUA.Server.add_namespace(pid, "Room")
+
+    # Object Node
+    requested_new_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_VendorName")
+
+    parent_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 85)
+    reference_type_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 35)
+    browse_name = QualifiedName.new(ns_index: ns_index, name: "Temperature sensor")
+    type_definition = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 58)
+
+    :ok = Server.add_object_node(pid,
+      requested_new_node_id: requested_new_node_id,
+      parent_node_id: parent_node_id,
+      reference_type_node_id: reference_type_node_id,
+      browse_name: browse_name,
+      type_definition: type_definition
+    )
+
+    # Variable Node
+    requested_new_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_Temperature")
+
+    parent_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_VendorName")
+
+    reference_type_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 47)
+    browse_name = QualifiedName.new(ns_index: ns_index, name: "Temperature")
+    type_definition = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 63)
+
+    :ok = Server.add_variable_node(pid,
+      requested_new_node_id: requested_new_node_id,
+      parent_node_id: parent_node_id,
+      reference_type_node_id: reference_type_node_id,
+      browse_name: browse_name,
+      type_definition: type_definition
+    )
+
+    :ok = Server.write_node_access_level(pid, requested_new_node_id, 3)
+    {:ok, 1} = Server.add_monitored_item(pid, monitored_item: requested_new_node_id, sampling_time: 500.0)
+
+    :ok = Server.start(pid)
+
+    {:ok, c_pid} = Client.start_link()
+    :ok = Client.set_config(c_pid)
+    :ok = Client.connect_by_url(c_pid, url: "opc.tcp://localhost:4840/")
+
+    %{c_pid: c_pid, ns_index: ns_index}
+  end
+
+  test "Add & delete a Subscription & Monitored Item", state do
+    node_id = NodeId.new(ns_index: state.ns_index, identifier_type: "string", identifier: "R1_TS1_Temperature")
+
+    assert {:ok, 1} == Client.add_subscription(state.c_pid)
+
+    assert {:ok, 1} == Client.add_monitored_item(state.c_pid, monitored_item: node_id, subscription_id: 1)
+
+    assert :ok == Client.write_node_value(state.c_pid, node_id, 10, 103103.0)
+    c_response = Client.read_node_value(state.c_pid, node_id)
+    assert c_response == {:ok, 103103.0}
+
+    assert_receive({%OpcUA.NodeId{identifier: "R1_TS1_Temperature", identifier_type: 1, ns_index: 2}, 103103.0}, 5000)
+    assert_receive({:data, 1, 1, 2}, 5000)
+    Process.sleep(1000000)
+
+    assert :ok == Client.delete_monitored_item(state.c_pid, monitored_item_id: 1, subscription_id: 1)
+
+    assert :ok == Client.delete_subscription(state.c_pid, 1)
+
+    # Subscription deleted
+    assert_receive({:delete, 1}, 1000)
+    # Monitored Item deleted
+    assert_receive({:delete, 1, 1}, 1000)
+
+    assert_receive({:delete, 1, 1, 2}, 5000)
+  end
+end

--- a/test/client_tests/monitored_items_test.exs
+++ b/test/client_tests/monitored_items_test.exs
@@ -45,7 +45,28 @@ defmodule ClientMonitoredItemsTest do
     )
 
     :ok = Server.write_node_access_level(pid, requested_new_node_id, 3)
-    {:ok, 1} = Server.add_monitored_item(pid, monitored_item: requested_new_node_id, sampling_time: 500.0)
+    {:ok, 1} = Server.add_monitored_item(pid, monitored_item: requested_new_node_id, sampling_time: 1000.0)
+
+    requested_new_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_Volts")
+
+    parent_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_VendorName")
+
+    reference_type_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 47)
+    browse_name = QualifiedName.new(ns_index: ns_index, name: "Volts")
+    type_definition = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 63)
+
+    :ok = Server.add_variable_node(pid,
+      requested_new_node_id: requested_new_node_id,
+      parent_node_id: parent_node_id,
+      reference_type_node_id: reference_type_node_id,
+      browse_name: browse_name,
+      type_definition: type_definition
+    )
+
+    :ok = Server.write_node_access_level(pid, requested_new_node_id, 3)
+    {:ok, 2} = Server.add_monitored_item(pid, monitored_item: requested_new_node_id, sampling_time: 1000.0)
 
     :ok = Server.start(pid)
 
@@ -57,29 +78,58 @@ defmodule ClientMonitoredItemsTest do
   end
 
   test "Add & delete a Subscription & Monitored Item", state do
-    node_id = NodeId.new(ns_index: state.ns_index, identifier_type: "string", identifier: "R1_TS1_Temperature")
+
+    node_id_1 = NodeId.new(ns_index: state.ns_index, identifier_type: "string", identifier: "R1_TS1_Temperature")
+    node_id_2 = NodeId.new(ns_index: state.ns_index, identifier_type: "string", identifier: "R1_TS1_Volts")
 
     assert {:ok, 1} == Client.add_subscription(state.c_pid)
 
-    assert {:ok, 1} == Client.add_monitored_item(state.c_pid, monitored_item: node_id, subscription_id: 1)
+    assert {:ok, 1} == Client.add_monitored_item(state.c_pid, monitored_item: node_id_1, subscription_id: 1)
+    assert {:ok, 2} == Client.add_monitored_item(state.c_pid, monitored_item: node_id_2, subscription_id: 1)
 
-    assert :ok == Client.write_node_value(state.c_pid, node_id, 10, 103103.0)
-    c_response = Client.read_node_value(state.c_pid, node_id)
+    assert :ok == Client.write_node_value(state.c_pid, node_id_1, 10, 103103.0)
+    c_response = Client.read_node_value(state.c_pid, node_id_1)
     assert c_response == {:ok, 103103.0}
 
-    assert_receive({%OpcUA.NodeId{identifier: "R1_TS1_Temperature", identifier_type: 1, ns_index: 2}, 103103.0}, 5000)
-    assert_receive({:data, 1, 1, 2}, 5000)
-    Process.sleep(1000000)
+    assert :ok == Client.write_node_value(state.c_pid, node_id_2, 10, 104104.0)
+    c_response = Client.read_node_value(state.c_pid, node_id_2)
+    assert c_response == {:ok, 104104.0}
+
+    Process.sleep(550)
+
+    assert :ok == Client.write_node_value(state.c_pid, node_id_1, 10, 103.0)
+    c_response = Client.read_node_value(state.c_pid, node_id_1)
+    assert c_response == {:ok, 103.0}
+
+    assert :ok == Client.write_node_value(state.c_pid, node_id_2, 10, 104104.0)
+    c_response = Client.read_node_value(state.c_pid, node_id_2)
+    assert c_response == {:ok, 104104.0}
+
+    Process.sleep(550)
 
     assert :ok == Client.delete_monitored_item(state.c_pid, monitored_item_id: 1, subscription_id: 1)
 
     assert :ok == Client.delete_subscription(state.c_pid, 1)
 
+    assert :ok == Client.write_node_value(state.c_pid, node_id_1, 10, 103.0)
+    c_response = Client.read_node_value(state.c_pid, node_id_1)
+    assert c_response == {:ok, 103.0}
+
+    assert :ok == Client.write_node_value(state.c_pid, node_id_2, 10, 104104.0)
+    c_response = Client.read_node_value(state.c_pid, node_id_2)
+    assert c_response == {:ok, 104104.0}
+
+    assert_receive({%OpcUA.NodeId{identifier: "R1_TS1_Temperature", identifier_type: 1, ns_index: 2}, 103103.0}, 5000)
+
+    # Updated data
+    assert_receive({:data, 1, 1, 103103.0}, 5000)
+    assert_receive({:data, 1, 2, 104104.0}, 5000)
+    assert_receive({:data, 1, 1, 103.0}, 5000)
     # Subscription deleted
     assert_receive({:delete, 1}, 1000)
     # Monitored Item deleted
     assert_receive({:delete, 1, 1}, 1000)
-
-    assert_receive({:delete, 1, 1, 2}, 5000)
+    #refute receive
+    refute_received({:data, 1, 2, 104104.0})
   end
 end

--- a/test/client_tests/terraform_test.exs
+++ b/test/client_tests/terraform_test.exs
@@ -100,8 +100,8 @@ defmodule ClientTerraformTest do
       %{parent_pid: parent_pid, opc_ua_client_pid: opc_ua_client_pid}
     end
 
-    def configuration(), do: Application.get_env(:my_client, :configuration, [])
-    def monitored_items(), do: Application.get_env(:my_client, :monitored_items, [])
+    def configuration(_user_init_state), do: Application.get_env(:my_client, :configuration, [])
+    def monitored_items(_user_init_state), do: Application.get_env(:my_client, :monitored_items, [])
 
     def read_node_value(pid, node), do: GenServer.call(pid, {:read, node})
 
@@ -121,8 +121,8 @@ defmodule ClientTerraformTest do
       %{parent_pid: parent_pid}
     end
 
-    def configuration(), do: Application.get_env(:my_server, :configuration, [])
-    def address_space(), do: Application.get_env(:my_server, :address_space, [])
+    def configuration(_user_init_state), do: Application.get_env(:my_server, :configuration, [])
+    def address_space(_user_init_state), do: Application.get_env(:my_server, :address_space, [])
 
     @impl true
     def handle_write(write_event, %{parent_pid: parent_pid} = state) do

--- a/test/client_tests/write_read_attr_test.exs
+++ b/test/client_tests/write_read_attr_test.exs
@@ -1,6 +1,5 @@
 defmodule CClientWriteAttrTest do
   use ExUnit.Case, async: false
-  doctest Opex62541
 
   alias OpcUA.{Client, ExpandedNodeId, NodeId, Server, QualifiedName}
 

--- a/test/server_tests/discovery_test.exs
+++ b/test/server_tests/discovery_test.exs
@@ -77,7 +77,7 @@ defmodule ServerDiscoveryTest do
 
     url = "opc.tcp://localhost:4050"
 
-    c_response = Client.get_endpoints(c_pid, url: url)
+    c_response = Client.get_endpoints(c_pid, url)
     assert c_response == desired
 
     desired =
@@ -104,7 +104,7 @@ defmodule ServerDiscoveryTest do
          }
        ]}
 
-    c_response = Client.find_servers(c_pid, url: url)
+    c_response = Client.find_servers(c_pid, url)
     assert c_response == desired
 
     desired =
@@ -126,7 +126,7 @@ defmodule ServerDiscoveryTest do
 
     url = "opc.tcp://localhost:4050/"
 
-    c_response = Client.find_servers_on_network(c_pid, url: url)
+    c_response = Client.find_servers_on_network(c_pid, url)
     assert c_response == desired
   end
 end

--- a/test/server_tests/discovery_test.exs
+++ b/test/server_tests/discovery_test.exs
@@ -1,6 +1,5 @@
 defmodule ServerDiscoveryTest do
   use ExUnit.Case, async: false
-  doctest Opex62541
 
   alias OpcUA.{Server, Client}
 

--- a/test/server_tests/lifecycle_test.exs
+++ b/test/server_tests/lifecycle_test.exs
@@ -1,6 +1,5 @@
 defmodule ServerLifecycleTest do
   use ExUnit.Case
-  doctest Opex62541
 
   #alias OpcUA.{NodeId, Server, QualifiedName}
   alias OpcUA.Server

--- a/test/server_tests/monitored_items_test.exs
+++ b/test/server_tests/monitored_items_test.exs
@@ -1,4 +1,4 @@
-defmodule MonitoredItemsTest do
+defmodule ServerMonitoredItemsTest do
   use ExUnit.Case
 
   alias OpcUA.{NodeId, Server, QualifiedName}

--- a/test/server_tests/monitored_items_test.exs
+++ b/test/server_tests/monitored_items_test.exs
@@ -1,0 +1,54 @@
+defmodule MonitoredItemsTest do
+  use ExUnit.Case
+
+  alias OpcUA.{NodeId, Server, QualifiedName}
+
+  setup do
+    {:ok, pid} = OpcUA.Server.start_link()
+    Server.set_default_config(pid)
+    {:ok, ns_index} = OpcUA.Server.add_namespace(pid, "Room")
+
+    # Object Node
+    requested_new_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_VendorName")
+
+    parent_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 85)
+    reference_type_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 35)
+    browse_name = QualifiedName.new(ns_index: ns_index, name: "Temperature sensor")
+    type_definition = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 58)
+
+    :ok = Server.add_object_node(pid,
+      requested_new_node_id: requested_new_node_id,
+      parent_node_id: parent_node_id,
+      reference_type_node_id: reference_type_node_id,
+      browse_name: browse_name,
+      type_definition: type_definition
+    )
+
+    # Variable Node
+    requested_new_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_Temperature")
+
+    parent_node_id =
+      NodeId.new(ns_index: ns_index, identifier_type: "string", identifier: "R1_TS1_VendorName")
+
+    reference_type_node_id = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 47)
+    browse_name = QualifiedName.new(ns_index: ns_index, name: "Temperature")
+    type_definition = NodeId.new(ns_index: 0, identifier_type: "integer", identifier: 63)
+
+    :ok = Server.add_variable_node(pid,
+      requested_new_node_id: requested_new_node_id,
+      parent_node_id: parent_node_id,
+      reference_type_node_id: reference_type_node_id,
+      browse_name: browse_name,
+      type_definition: type_definition
+    )
+
+    %{pid: pid, ns_index: ns_index}
+  end
+
+  test "Add a monitored Item", state do
+    node_id = NodeId.new(ns_index: state.ns_index, identifier_type: "string", identifier: "R1_TS1_Temperature")
+    assert :ok == Server.add_monitored_item(state.pid, monitored_item: node_id, sampling_time: 1000.0)
+  end
+end

--- a/test/server_tests/monitored_items_test.exs
+++ b/test/server_tests/monitored_items_test.exs
@@ -47,8 +47,11 @@ defmodule MonitoredItemsTest do
     %{pid: pid, ns_index: ns_index}
   end
 
-  test "Add a monitored Item", state do
+  test "Add & delete a monitored Item", state do
     node_id = NodeId.new(ns_index: state.ns_index, identifier_type: "string", identifier: "R1_TS1_Temperature")
-    assert :ok == Server.add_monitored_item(state.pid, monitored_item: node_id, sampling_time: 1000.0)
+    assert {:ok, 1} == Server.add_monitored_item(state.pid, monitored_item: node_id, sampling_time: 1000.0)
+    # Expected error with a undefined monitored item.
+    assert {:error, "BadMonitoredItemIdInvalid"} == Server.delete_monitored_item(state.pid, 10)
+    assert :ok == Server.delete_monitored_item(state.pid, 1)
   end
 end

--- a/test/server_tests/node_addition_deletion_test.exs
+++ b/test/server_tests/node_addition_deletion_test.exs
@@ -1,6 +1,5 @@
 defmodule ServerNodeAdditionDeletionTest do
   use ExUnit.Case
-  doctest Opex62541
 
   alias OpcUA.{NodeId, Server, QualifiedName}
 

--- a/test/server_tests/terraform_test.exs
+++ b/test/server_tests/terraform_test.exs
@@ -86,8 +86,8 @@ defmodule ServerTerraformTest do
       %{parent_pid: parent_pid}
     end
 
-    def configuration(), do: Application.get_env(:opex62541, :configuration, [])
-    def address_space(), do: Application.get_env(:opex62541, :address_space, [])
+    def configuration(_user_init_state), do: Application.get_env(:opex62541, :configuration, [])
+    def address_space(_user_init_state), do: Application.get_env(:opex62541, :address_space, [])
 
     def handle_write(write_event, %{parent_pid: parent_pid} = state) do
       send(parent_pid, write_event)

--- a/test/server_tests/write_attr_test.exs
+++ b/test/server_tests/write_attr_test.exs
@@ -1,6 +1,5 @@
 defmodule WriteAttrTest do
   use ExUnit.Case
-  doctest Opex62541
 
   alias OpcUA.{NodeId, Server, QualifiedName}
 

--- a/test/server_tests/write_event_test.exs
+++ b/test/server_tests/write_event_test.exs
@@ -10,8 +10,6 @@ defmodule ServerWriteEventTest do
 
     # Use the `init` function to configure your server.
     def init({parent_pid, 103}, s_pid) do
-      #{:ok, s_pid} = Server.start_link()
-      #:ok = Server.set_default_config(s_pid)
 
       {:ok, _ns_index} = Server.add_namespace(s_pid, "Room")
 
@@ -63,7 +61,7 @@ defmodule ServerWriteEventTest do
 
     @impl true
     def handle_write(write_event, %{parent_pid: parent_pid} = state) do
-      Logger.debug("(#{__MODULE__} Received #{inspect(write_event)})")
+      Logger.debug("(#{__MODULE__}) Received #{inspect(write_event)})")
       send(parent_pid, write_event)
       state
     end


### PR DESCRIPTION
# Description

OPC UA Client and Server supports Subscription (Monitored Items) behavior; Monitored Items & Subscriptions functions added to the Client and Server; Client terraform behavior handles configuration, monitored Items and callbacks for subscription_timeout, deleted_subscription, monitored_data and deleted_monitored_item; Server terraform address_space supports monitored items too. Finally commented code to run Valgrind (memory leak search) test added.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
test/client_tests/monitored_items_test.exs
test/client_tests/terraform_test.exs
test/server_tests/monitored_items_test.exs

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
