### PR TITLE
Reference hex.pm package in instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ To install this package, add `opex62541` to your list of dependencies in `mix.ex
 ```elixir
 def deps do
   [
-    {:opex62541, git: "https://github.com/valiot/opex62541"}
+    {:opex62541, "~> 0.1.2"}
   ]
 end
 ```


### PR DESCRIPTION
I assume that since this has been published to hex.pm that you want people to use the hex package instead of the latest `master` branch commit of the GitHub repository.